### PR TITLE
Multiple folder initializers

### DIFF
--- a/lib/phases/initializers.js
+++ b/lib/phases/initializers.js
@@ -28,33 +28,66 @@ module.exports = function(options) {
   if ('string' == typeof options) {
     options = { dirname: options };
   }
+
   options = options || {};
-  var dirname = options.dirname || 'etc/init'
+  var dirnames = []
     , extensions = options.extensions || Object.keys(require.extensions).map(function(ext) { return ext; })
     , exts = extensions.map(function(ext) {
         if ('.' != ext[0]) { return ext; }
         return ext.slice(1);
       })
     , regex = new RegExp('\\.(' + exts.join('|') + ')$');
-  
+
+   if (Array.isArray(options.dirname)) {
+     dirnames = options.dirname;
+   }
+   else{
+     dirnames.push(options.dirname || '/etc/init/');
+   }
+
   return function initializers(done) {
-    var dir = path.resolve(dirname);
-    if (!existsSync(dir)) { return done(); }
-    
-    var self = this
-      , files = fs.readdirSync(dir).sort()
-      , idx = 0;
+
+    var dirs = [],
+        files = [],
+        self = this,
+        idx = 0;
+
+    dirs = dirnames.filter(function(dirname){
+      var folder = path.resolve(dirname);
+      if (!existsSync(folder)) {
+        return false;
+      }
+      return true;
+    }).map(function(dirname){
+      return path.resolve(dirname);;
+    });
+
+    //Sanity check
+    if (dirs.length !== dirnames.length) {
+      return done(new Error('One or more directory does not exist'));
+    }
+
+    files = dirs.map(function(dir){
+      return fs.readdirSync(dir).map(function(file){
+        return {filename:file, filePath:path.join(dir, file)}
+      });
+    });
+
+    //Flatten and sort array of array to one level array.
+    files = [].concat.apply([], files).sort();
+
     function next(err) {
       if (err) { return done(err); }
-    
+
       var file = files[idx++];
       // all done
       if (!file) { return done(); }
-    
-      if (regex.test(file)) {
+
+      if (regex.test(file.filename)) {
         try {
-          debug('initializer %s', file);
-          var mod = require(path.join(dir, file));
+
+          var mod = require(file.filePath);
+
           if (typeof mod == 'function') {
             var arity = mod.length;
             if (arity == 1) {

--- a/lib/phases/initializers.js
+++ b/lib/phases/initializers.js
@@ -29,6 +29,10 @@ module.exports = function(options) {
     options = { dirname: options };
   }
 
+  if (Array.isArray(options)) {
+    options = {dirname: options};
+  }
+
   options = options || {};
   var dirnames = []
     , extensions = options.extensions || Object.keys(require.extensions).map(function(ext) { return ext; })

--- a/lib/phases/initializers.js
+++ b/lib/phases/initializers.js
@@ -78,7 +78,16 @@ module.exports = function(options) {
     });
 
     //Flatten and sort array of array to one level array.
-    files = [].concat.apply([], files).sort();
+    files = [].concat.apply([], files).sort(function(a, b){
+      if (a.filename < b.filename) {
+        return -1;
+      }
+      if (a.filename > b.filename) {
+        return 1;
+      }
+
+      return 0;
+    });
 
     function next(err) {
       if (err) { return done(err); }

--- a/test/data/initializers/test-multiple-folders/04_log.js
+++ b/test/data/initializers/test-multiple-folders/04_log.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  this.order.push('04_log');
+};

--- a/test/data/initializers/test-multiple-folders/README.md
+++ b/test/data/initializers/test-multiple-folders/README.md
@@ -1,0 +1,1 @@
+# Initializers

--- a/test/phases/initializers.test.js
+++ b/test/phases/initializers.test.js
@@ -36,6 +36,33 @@ describe('phases/initializers', function() {
     });
   });
 
+  describe('phase with Array argument', function() {
+    var app = new Object();
+    app.order = [];
+
+    var error;
+
+    before(function(done) {
+
+      var phase = initializers([__dirname + '/../data/initializers/test', __dirname + '/../data/initializers/test-multiple-folders']);
+      phase.call(app, function(err) {
+        error = err;
+        return done();
+      });
+    });
+
+    it('should call callback', function() {
+      expect(error).to.be.undefined;
+    });
+
+    it('should run initializers in correct order', function() {
+      expect(app.order).to.have.length(3);
+      expect(app.order[0]).to.equal('01_async');
+      expect(app.order[1]).to.equal('02_sync');
+      expect(app.order[2]).to.equal('04_log');
+    });
+  });
+
   describe('phase with dirname option', function() {
     var app = new Object();
     app.order = [];
@@ -106,7 +133,6 @@ describe('phases/initializers', function() {
       });
 
     });
-
   });
 
   describe('phase with initializer that calls done with error', function() {

--- a/test/phases/initializers.test.js
+++ b/test/phases/initializers.test.js
@@ -3,20 +3,20 @@
 var initializers = require('../../lib/phases/initializers');
 
 describe('phases/initializers', function() {
-  
+
   it('should export a setup function', function() {
     expect(initializers).to.be.a('function');
   });
-  
+
   describe('phase with string argument', function() {
     var app = new Object();
     app.order = [];
-    
+
     var error;
-    
+
     before(function(done) {
       global.__app = app;
-      
+
       var phase = initializers(__dirname + '/../data/initializers/test');
       phase.call(app, function(err) {
         error = err;
@@ -24,7 +24,7 @@ describe('phases/initializers', function() {
         return done();
       });
     });
-    
+
     it('should call callback', function() {
       expect(error).to.be.undefined;
     });
@@ -35,13 +35,13 @@ describe('phases/initializers', function() {
       expect(app.order[2]).to.equal('03_require');
     });
   });
-  
+
   describe('phase with dirname option', function() {
     var app = new Object();
     app.order = [];
-    
+
     var error;
-    
+
     before(function(done) {
       var phase = initializers({ dirname: __dirname + '/../data/initializers/test' });
       phase.call(app, function(err) {
@@ -49,23 +49,72 @@ describe('phases/initializers', function() {
         return done();
       });
     });
-    
+
     it('should call callback', function() {
       expect(error).to.be.undefined;
     });
+
     it('should run initializers in correct order', function() {
       expect(app.order).to.have.length(2);
       expect(app.order[0]).to.equal('01_async');
       expect(app.order[1]).to.equal('02_sync');
     });
   });
-  
+
+  describe('phase with multiple dirname options', function(){
+    var app = new Object();
+    app.order = [];
+
+    var error;
+
+    before(function(done) {
+      var phase = initializers({ dirname: [__dirname + '/../data/initializers/test', __dirname + '/../data/initializers/test-multiple-folders'] });
+      phase.call(app, function(err) {
+        error = err;
+        return done();
+      });
+    });
+
+    it('should call callback', function() {
+      expect(error).to.be.undefined;
+    });
+
+    it('should run initializers in correct order', function() {
+      expect(app.order).to.have.length(3);
+      expect(app.order[0]).to.equal('01_async');
+      expect(app.order[1]).to.equal('02_sync');
+      expect(app.order[2]).to.equal('04_log');
+    });
+
+    describe('error in path, should not be imported', function(){
+      var app = new Object();
+      app.order = [];
+
+      var error;
+
+      before(function(done) {
+        var phase = initializers({ dirname: [__dirname + '/../data/initializers/test', __dirname + '/../data/initializers/test-multiple-foldssers'] });
+        phase.call(app, function(err) {
+          error = err;
+          return done();
+        });
+      });
+
+      it('should call callback', function() {
+        expect(error).to.be.an.instanceOf(Error);
+        expect(error.message).to.equal('One or more directory does not exist');
+      });
+
+    });
+
+  });
+
   describe('phase with initializer that calls done with error', function() {
     var app = new Object();
     app.order = [];
-    
+
     var error;
-    
+
     before(function(done) {
       var phase = initializers(__dirname + '/../data/initializers/error-done');
       phase.call(app, function(err) {
@@ -73,7 +122,7 @@ describe('phases/initializers', function() {
         return done();
       });
     });
-    
+
     it('should call callback', function() {
       expect(error).to.be.an.instanceOf(Error);
       expect(error.message).to.equal('something went wrong');
@@ -82,13 +131,13 @@ describe('phases/initializers', function() {
       expect(app.order).to.have.length(0);
     });
   });
-  
+
   describe('phase with initializer that throws exception', function() {
     var app = new Object();
     app.order = [];
-    
+
     var error;
-    
+
     before(function(done) {
       var phase = initializers(__dirname + '/../data/initializers/error-throw');
       phase.call(app, function(err) {
@@ -96,7 +145,7 @@ describe('phases/initializers', function() {
         return done();
       });
     });
-    
+
     it('should call callback', function() {
       expect(error).to.be.an.instanceOf(Error);
       expect(error.message).to.equal('something went horribly wrong');
@@ -105,5 +154,5 @@ describe('phases/initializers', function() {
       expect(app.order).to.have.length(0);
     });
   });
-  
+
 });

--- a/test/phases/initializers.test.js
+++ b/test/phases/initializers.test.js
@@ -44,7 +44,7 @@ describe('phases/initializers', function() {
 
     before(function(done) {
 
-      var phase = initializers([__dirname + '/../data/initializers/test', __dirname + '/../data/initializers/test-multiple-folders']);
+      var phase = initializers([__dirname + '/../data/initializers/test-multiple-folders', __dirname + '/../data/initializers/test']);
       phase.call(app, function(err) {
         error = err;
         return done();


### PR DESCRIPTION
Hi,

In a transition step from a monolith to something a little more micro, we needed to be able to import multiple folders with bootable initializers.

It works by passing an Array to `bootable.initializers` (or dirname:Array).

Would you like to merge it ?
I have run test on node 4.x and 0.10.x.
